### PR TITLE
Add Rileylink battery level in device information

### DIFF
--- a/RileyLinkBLEKit/PeripheralManager+RileyLink.swift
+++ b/RileyLinkBLEKit/PeripheralManager+RileyLink.swift
@@ -19,6 +19,7 @@ extension CBUUIDRawValue where RawValue == String {
 
 enum RileyLinkServiceUUID: String, CBUUIDRawValue {
     case main = "0235733B-99C5-4197-B856-69219C2A3845"
+    case battery = "180F"
 }
 
 enum MainServiceCharacteristicUUID: String, CBUUIDRawValue {
@@ -28,6 +29,10 @@ enum MainServiceCharacteristicUUID: String, CBUUIDRawValue {
     case timerTick       = "6E6C7910-B89E-43A5-78AF-50C5E2B86F7E"
     case firmwareVersion = "30D99DC9-7C91-4295-A051-0A104D238CF2"
     case ledMode         = "C6D84241-F1A7-4F9C-A25F-FCE16732F14E"
+}
+
+enum BatteryServiceCharacteristicUUID: String, CBUUIDRawValue {
+    case battery_level   = "2A19"
 }
 
 enum RileyLinkLEDMode: UInt8 {
@@ -48,6 +53,9 @@ extension PeripheralManager.Configuration {
                     MainServiceCharacteristicUUID.timerTick.cbUUID,
                     MainServiceCharacteristicUUID.firmwareVersion.cbUUID,
                     MainServiceCharacteristicUUID.ledMode.cbUUID
+                    ],
+                RileyLinkServiceUUID.battery.cbUUID: [
+                    BatteryServiceCharacteristicUUID.battery_level.cbUUID
                 ]
             ],
             notifyingCharacteristics: [
@@ -74,6 +82,17 @@ extension PeripheralManager.Configuration {
 
 fileprivate extension CBPeripheral {
     func getCharacteristicWithUUID(_ uuid: MainServiceCharacteristicUUID, serviceUUID: RileyLinkServiceUUID = .main) -> CBCharacteristic? {
+        guard let service = services?.itemWithUUID(serviceUUID.cbUUID) else {
+            return nil
+        }
+
+        return service.characteristics?.itemWithUUID(uuid.cbUUID)
+    }
+}
+
+
+fileprivate extension CBPeripheral {
+    func getBatteryCharacteristic(_ uuid: BatteryServiceCharacteristicUUID, serviceUUID: RileyLinkServiceUUID = .battery) -> CBCharacteristic? {
         guard let service = services?.itemWithUUID(serviceUUID.cbUUID) else {
             return nil
         }
@@ -286,6 +305,25 @@ extension PeripheralManager {
             }
 
             return version
+        } catch let error as PeripheralManagerError {
+            throw RileyLinkDeviceError.peripheralManagerError(error)
+        }
+    }
+
+    func readBatteryLevel(timeout: TimeInterval) throws -> String {
+        guard let characteristic = peripheral.getBatteryCharacteristic(.battery_level) else {
+            throw RileyLinkDeviceError.peripheralManagerError(.unknownCharacteristic)
+        }
+
+        do {
+            guard let data = try readValue(for: characteristic, timeout: timeout) else {
+                // TODO: This is an "unknown value" issue, not a timeout
+                throw RileyLinkDeviceError.peripheralManagerError(.timeout)
+            }
+
+            let battery_level = "\(data[0])"
+
+            return battery_level
         } catch let error as PeripheralManagerError {
             throw RileyLinkDeviceError.peripheralManagerError(error)
         }

--- a/RileyLinkBLEKit/RileyLinkDevice.swift
+++ b/RileyLinkBLEKit/RileyLinkDevice.swift
@@ -93,6 +93,12 @@ extension RileyLinkDevice {
         manager.setCustomName(name)
     }
     
+    public func getBatterylevel(_ completion: @escaping (_ batteryLevel: String?) -> Void) {
+        self.manager.queue.async {
+            completion(try? self.manager.readBatteryLevel(timeout: 1))
+        }
+    }
+    
     public func enableBLELEDs() {
         manager.setLEDMode(mode: .on)
     }


### PR DESCRIPTION
Remove unnecessary use of session

Fix optional value

Show battery level only if device is an EmaLink or reports battery level